### PR TITLE
Implement weather ETL workflow scripts

### DIFF
--- a/basic.sh
+++ b/basic.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Initialize project data files used by the weather ETL workflow.
+set -euo pipefail
+
+LOG_FILE=${1:-rx_poc.log}
+ACCURACY_FILE=${2:-historical_fc_accuracy.tsv}
+INPUT_TEMPLATE=${3:-rx_poc_manual_input.tsv}
+
+ensure_header() {
+  local file=$1
+  local header=$2
+  if [[ ! -f $file || ! -s $file ]]; then
+    printf '%s\n' "$header" >"$file"
+    echo "Initialized $file with header"
+    return
+  fi
+  local existing
+  existing=$(head -n1 "$file" || true)
+  if [[ $existing != "$header" ]]; then
+    {
+      printf '%s\n' "$header"
+      tail -n +2 "$file" 2>/dev/null || true
+    } >"${file}.tmp"
+    mv "${file}.tmp" "$file"
+    echo "Reset header for $file"
+  fi
+}
+
+ensure_log() {
+  ensure_header "$LOG_FILE" $'year\tmonth\tday\tobs_temp\tfc_temp'
+}
+
+ensure_accuracy() {
+  ensure_header "$ACCURACY_FILE" $'year\tmonth\tday\tobs_temp\tfc_temp\taccuracy\taccuracy_range'
+}
+
+ensure_template() {
+  ensure_header "$INPUT_TEMPLATE" $'year\tmonth\tday\tobs_temp\tfc_temp'
+  if ! grep -q '^#' "$INPUT_TEMPLATE"; then
+    {
+      printf '%s\n' $'# Add additional rows below using tab-separated values, e.g.:'
+      printf '%s\n' $'# 2024\t05\t01\t23.5\t24.0'
+    } >>"$INPUT_TEMPLATE"
+  fi
+}
+
+ensure_log
+ensure_accuracy
+ensure_template

--- a/fc_accuracy.sh
+++ b/fc_accuracy.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Generate historical forecast accuracy metrics from rx_poc.log entries.
+set -euo pipefail
+
+LOG_FILE=${1:-rx_poc.log}
+OUTPUT_FILE=${2:-historical_fc_accuracy.tsv}
+
+if [[ ! -f $LOG_FILE ]]; then
+  echo "Input log $LOG_FILE does not exist." >&2
+  exit 1
+fi
+
+TMP_FILE=$(mktemp)
+trap 'rm -f "$TMP_FILE"' EXIT
+
+printf 'year\tmonth\tday\tobs_temp\tfc_temp\taccuracy\taccuracy_range\n' >"$TMP_FILE"
+
+AWK_SCRIPT='BEGIN {FS="\t"}
+NR==1 {next}
+/^#/ {next}
+/^[[:space:]]*$/ {next}
+{
+  if (!has_prev) {
+    prev_fc=$5;
+    has_prev=1;
+    next;
+  }
+  obs=$4+0
+  fc_prev=prev_fc+0
+  err=fc_prev-obs
+  abs_err=(err < 0) ? -err : err
+  if (abs_err <= 1) {
+    range="excellent"
+  } else if (abs_err <= 2) {
+    range="good"
+  } else if (abs_err <= 4) {
+    range="fair"
+  } else {
+    range="poor"
+  }
+  printf "%s\t%s\t%s\t%.1f\t%.1f\t%.1f\t%s\n", $1, $2, $3, obs, fc_prev, err, range
+  prev_fc=$5;
+  records++
+}'
+
+if ! awk "$AWK_SCRIPT" "$LOG_FILE" >>"$TMP_FILE"; then
+  echo "Failed to compute forecast accuracy" >&2
+  exit 1
+fi
+
+line_count=$(wc -l <"$TMP_FILE")
+if (( line_count <= 1 )); then
+  echo "Log $LOG_FILE does not yet have enough entries to calculate accuracy." >&2
+  mv "$TMP_FILE" "$OUTPUT_FILE"
+  exit 0
+fi
+
+mv "$TMP_FILE" "$OUTPUT_FILE"
+echo "Wrote forecast accuracy metrics to $OUTPUT_FILE"

--- a/historical_fc_accuracy.tsv
+++ b/historical_fc_accuracy.tsv
@@ -1,0 +1,1 @@
+year	month	day	obs_temp	fc_temp	accuracy	accuracy_range

--- a/readme.md
+++ b/readme.md
@@ -15,11 +15,20 @@ By following the exercises in this project you will learn how to:
 ## Repository Structure
 | File | Description |
 | --- | --- |
-| `rx_poc.sh` | Intended Bash ETL script that downloads Casablanca weather data, extracts current and forecast temperatures, and appends a record to `rx_poc.log`. **Note:** the file is currently empty and must be populated with the logic outlined in Exercises 2 and 3 below.【62e87d†L1-L5】 |
-| `rx_poc.log` | Tab-delimited log file that stores the daily observations. Presently empty pending script execution.【62e87d†L5-L6】 |
-| `fc_accuracy.sh` | Placeholder for the historical forecast accuracy calculator described in Exercise 5. The script has not yet been implemented.【62e87d†L1-L4】 |
-| `weekly_stats.sh` | Bash utility that ingests the last seven forecast accuracy values, converts them to absolute errors, and reports weekly min/max statistics. The current version includes extra tutorial artifacts ("Copied!", "Wrap Toggled!") that should be removed before production use.【d86971†L1-L34】 |
-| `basic.sh` | Empty helper script placeholder.【62e87d†L1-L2】 |
+| `rx_poc.sh` | Bash ETL script that downloads Casablanca weather data from wttr.in, extracts current and next-day noon temperatures, and appends a deduplicated record to `rx_poc.log`. |
+| `rx_poc.log` | Tab-delimited log populated by `rx_poc.sh`. The header is created automatically when missing. |
+| `fc_accuracy.sh` | Processes `rx_poc.log` to calculate signed forecast errors, classify their accuracy ranges, and write `historical_fc_accuracy.tsv`. |
+| `weekly_stats.sh` | Validates the derived accuracy dataset and reports weekly minimum and maximum absolute errors. |
+| `basic.sh` | Utility helper that initializes the log, accuracy dataset, and manual input template for new environments. |
+| `rx_poc_manual_input.tsv` | Tab-delimited template that end users can populate manually when testing the accuracy workflow without calling the API. |
+
+## Quick Start
+1. Run `./basic.sh` to ensure the log (`rx_poc.log`), derived dataset (`historical_fc_accuracy.tsv`), and manual template (`rx_poc_manual_input.tsv`) exist with the correct headers.
+2. Execute `./rx_poc.sh` to download the latest Casablanca observation and next-day forecast. The script prevents duplicate entries for the same local day and stores the raw API response in `weather_report.json`.
+3. Optionally append manual records to `rx_poc_manual_input.tsv` and point `fc_accuracy.sh` at that file when testing without network access: `./fc_accuracy.sh rx_poc_manual_input.tsv manual_accuracy.tsv`.
+4. Generate the accuracy dataset with `./fc_accuracy.sh`. When the log contains at least two entries, the script will produce `historical_fc_accuracy.tsv` with signed errors and qualitative accuracy ranges.
+5. Summarize the latest forecast performance with `./weekly_stats.sh [path/to/accuracy.tsv]`, which reports the minimum and maximum absolute error across the most recent seven records.
+
 
 ## Prerequisites
 - Linux or macOS environment with Bash 4+, `curl`, `wget`, `grep`, `cut`, `head`, `tail`, and `date` available.

--- a/rx_poc.log
+++ b/rx_poc.log
@@ -1,0 +1,1 @@
+year	month	day	obs_temp	fc_temp

--- a/rx_poc.sh
+++ b/rx_poc.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Collect Casablanca weather observations and forecasts from wttr.in.
+set -euo pipefail
+
+CITY="Casablanca"
+LOG_FILE="rx_poc.log"
+RAW_OUTPUT="weather_report.json"
+TZ_REGION="Africa/Casablanca"
+
+declare -a CLEANUP_FILES
+
+usage() {
+  cat <<USAGE
+Usage: ${0##*/} [-c city] [-l log_file] [-o raw_output]
+  -c city        City name understood by wttr.in (default: Casablanca)
+  -l log_file    Log file to append tab-delimited weather records (default: rx_poc.log)
+  -o raw_output  Path to store the most recent raw API payload (default: weather_report.json)
+USAGE
+}
+
+while getopts ":c:l:o:h" opt; do
+  case "$opt" in
+    c) CITY=$OPTARG ;;
+    l) LOG_FILE=$OPTARG ;;
+    o) RAW_OUTPUT=$OPTARG ;;
+    h)
+      usage
+      exit 0
+      ;;
+    :)
+      echo "Missing value for -$OPTARG" >&2
+      usage >&2
+      exit 1
+      ;;
+    ?)
+      echo "Unknown option: -$OPTARG" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+mkdir -p "$(dirname "$RAW_OUTPUT")"
+API_URL="https://wttr.in/${CITY// /%20}?format=j1"
+TEMP_JSON=$(mktemp)
+CLEANUP_FILES+=("$TEMP_JSON")
+trap 'for f in "${CLEANUP_FILES[@]}"; do [[ -f $f ]] && rm -f "$f"; done' EXIT
+
+if ! curl -fsS --retry 3 --retry-delay 2 "$API_URL" -o "$TEMP_JSON"; then
+  echo "Failed to download weather data from wttr.in for $CITY" >&2
+  exit 1
+fi
+
+if ! cp "$TEMP_JSON" "$RAW_OUTPUT"; then
+  echo "Unable to write raw response to $RAW_OUTPUT" >&2
+  exit 1
+fi
+
+read -r OBS_TEMP FC_TEMP <<VALUES
+$(python3 - "$TEMP_JSON" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload_path = Path(sys.argv[1])
+with payload_path.open("r", encoding="utf-8") as handle:
+    data = json.load(handle)
+
+try:
+    current = data["current_condition"][0]
+    obs = float(current["temp_C"])
+except (KeyError, IndexError, ValueError) as exc:  # pragma: no cover
+    raise SystemExit(f"Unable to read observed temperature: {exc}") from exc
+
+weather_periods = data.get("weather", [])
+if len(weather_periods) >= 2:
+    tomorrow = weather_periods[1]
+else:
+    tomorrow = weather_periods[0] if weather_periods else None
+
+if not tomorrow:
+    raise SystemExit("Weather forecast data is unavailable in the payload")
+
+hourly = tomorrow.get("hourly", [])
+if not hourly:
+    raise SystemExit("Hourly forecast data missing from payload")
+
+midday_slot = min(
+    hourly,
+    key=lambda entry: abs(int(entry.get("time", "0") or "0") - 1200),
+)
+
+try:
+    forecast = float(midday_slot["tempC"])
+except (KeyError, ValueError) as exc:  # pragma: no cover
+    raise SystemExit(f"Unable to read forecast temperature: {exc}") from exc
+
+print(f"{obs:.1f} {forecast:.1f}")
+PY
+)
+VALUES
+
+if [[ -z ${OBS_TEMP:-} || -z ${FC_TEMP:-} ]]; then
+  echo "Failed to parse observed or forecast temperature" >&2
+  exit 1
+fi
+
+expected_header=$'year\tmonth\tday\tobs_temp\tfc_temp'
+if [[ ! -f $LOG_FILE || ! -s $LOG_FILE ]]; then
+  printf '%s\n' "$expected_header" >"$LOG_FILE"
+elif [[ $(head -n1 "$LOG_FILE") != $expected_header ]]; then
+  {
+    printf '%s\n' "$expected_header"
+    tail -n +2 "$LOG_FILE" 2>/dev/null || true
+  } >"$LOG_FILE.tmp"
+  mv "$LOG_FILE.tmp" "$LOG_FILE"
+fi
+
+YEAR=$(TZ="$TZ_REGION" date +%Y)
+MONTH=$(TZ="$TZ_REGION" date +%m)
+DAY=$(TZ="$TZ_REGION" date +%d)
+
+if awk -F '\t' -v y="$YEAR" -v m="$MONTH" -v d="$DAY" 'NR>1 && $1==y && $2==m && $3==d {exit 0} END {exit 1}' "$LOG_FILE"; then
+  echo "An entry for $YEAR-$MONTH-$DAY already exists in $LOG_FILE. Skipping append." >&2
+  exit 0
+fi
+
+printf '%s\t%s\t%s\t%.1f\t%.1f\n' "$YEAR" "$MONTH" "$DAY" "$OBS_TEMP" "$FC_TEMP" >>"$LOG_FILE"
+echo "Appended weather record for $YEAR-$MONTH-$DAY to $LOG_FILE"

--- a/rx_poc_manual_input.tsv
+++ b/rx_poc_manual_input.tsv
@@ -1,0 +1,3 @@
+year	month	day	obs_temp	fc_temp
+# Add additional rows below using tab-separated values, e.g.:
+# 2024	05	01	23.5	24.0

--- a/weekly_stats.sh
+++ b/weekly_stats.sh
@@ -1,34 +1,34 @@
-#!/bin/bash
-echo $(tail -7 synthetic_historical_fc_accuracy.tsv  | cut -f6) > scratch.txt
-week_fc=($(echo $(cat scratch.txt)))
-# validate result:
-for i in {0..6}; do
-    echo ${week_fc[$i]}
-done
-for i in {0..6}; do
-  if [[ ${week_fc[$i]} < 0 ]]
-  then
-    week_fc[$i]=$(((-1)*week_fc[$i]))
-  fi
-  # validate result:
-  echo ${week_fc[$i]}
-done
-minimum=${week_fc[1]}
-maximum=${week_fc[1]}
-for item in ${week_fc[@]}; do
-   if [[ $minimum > $item ]]
-   then
-     minimum=$item
-   fi
-   if [[ $maximum < $item ]]
-   then
-     maximum=$item
-   fi
-done
-echo "minimum ebsolute error = $minimum"
-echo "maximum absolute error = $maximum"
+#!/usr/bin/env bash
+# Report min/max absolute forecast errors over the most recent seven days.
+set -euo pipefail
 
-Copied!
+ACCURACY_FILE=${1:-historical_fc_accuracy.tsv}
 
-Wrap Toggled!
+if [[ ! -f $ACCURACY_FILE ]]; then
+  echo "Accuracy file $ACCURACY_FILE does not exist." >&2
+  exit 1
+fi
 
+mapfile -t recent_accuracy < <(tail -n +2 "$ACCURACY_FILE" | awk -F '\t' '{print $6}' | sed '/^\s*$/d' | tail -n 7)
+
+if ((${#recent_accuracy[@]} == 0)); then
+  echo "No accuracy readings available in $ACCURACY_FILE." >&2
+  exit 1
+fi
+
+if ((${#recent_accuracy[@]} < 7)); then
+  echo "Warning: fewer than seven accuracy values available; using ${#recent_accuracy[@]} entries." >&2
+fi
+
+abs_values=()
+for value in "${recent_accuracy[@]}"; do
+  abs_values+=("$(awk -v v="$value" 'BEGIN {if (v < 0) v = -v; printf "%.2f", v}')")
+done
+
+read -r min_error max_error <<RANGE
+$(printf '%s\n' "${abs_values[@]}" | awk 'NR==1 {min=$1; max=$1} {if ($1+0 < min+0) min=$1; if ($1+0 > max+0) max=$1} END {printf "%.2f %.2f", min, max}')
+RANGE
+
+echo "Processed ${#abs_values[@]} accuracy values from $ACCURACY_FILE"
+echo "Minimum absolute error: ${min_error}°C"
+echo "Maximum absolute error: ${max_error}°C"


### PR DESCRIPTION
## Summary
- add weather ingestion script that fetches wttr.in JSON, normalizes headers, and appends deduplicated Casablanca records
- implement forecast accuracy calculator, weekly stats report, and initialization helper with reusable headers and manual input template
- refresh documentation to describe the runnable scripts and provide a manual data-entry file

## Testing
- ./basic.sh
- ./fc_accuracy.sh rx_poc_manual_input.tsv manual_accuracy.tsv

------
https://chatgpt.com/codex/tasks/task_e_68ca7f09c3f48327a97b01c330e58477