### PR TITLE
Add GitHub Action to run weather pipeline

### DIFF
--- a/.github/workflows/weather-pipeline.yml
+++ b/.github/workflows/weather-pipeline.yml
@@ -1,0 +1,93 @@
+name: Weather data pipeline
+
+on:
+  workflow_dispatch:
+    inputs:
+      city:
+        description: "City name understood by wttr.in"
+        required: false
+        default: "Casablanca"
+
+jobs:
+  run-pipeline:
+    name: Run weather ETL pipeline
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Ensure scripts are executable
+        run: |
+          chmod +x basic.sh rx_poc.sh fc_accuracy.sh weekly_stats.sh
+
+      - name: Execute weather pipeline
+        id: pipeline
+        env:
+          CITY: ${{ inputs.city }}
+        run: |
+          set -euo pipefail
+
+          WORKDIR="pipeline_outputs"
+          mkdir -p "$WORKDIR"
+
+          LOG_PATH="$WORKDIR/rx_poc.log"
+          ACCURACY_PATH="$WORKDIR/historical_fc_accuracy.tsv"
+          RAW_PATH="$WORKDIR/weather_report.json"
+          TEMPLATE_PATH="$WORKDIR/rx_poc_manual_input.tsv"
+
+          echo "Initializing data files"
+          ./basic.sh "$LOG_PATH" "$ACCURACY_PATH" "$TEMPLATE_PATH"
+
+          echo "Collecting weather observation and forecast for $CITY"
+          ./rx_poc.sh -c "$CITY" -l "$LOG_PATH" -o "$RAW_PATH"
+
+          echo "Computing historical accuracy dataset"
+          ./fc_accuracy.sh "$LOG_PATH" "$ACCURACY_PATH"
+
+          SUMMARY_FILE="$WORKDIR/weekly_stats.txt"
+          if [[ $(wc -l <"$ACCURACY_PATH") -gt 1 ]]; then
+            echo "Generating weekly statistics"
+            ./weekly_stats.sh "$ACCURACY_PATH" | tee "$SUMMARY_FILE"
+          else
+            echo "Not enough accuracy records to compute weekly statistics" | tee "$SUMMARY_FILE"
+          fi
+
+          {
+            echo "### Weather Pipeline Summary"
+            echo ""
+            echo "* **City:** $CITY"
+            echo "* **Log file:** $LOG_PATH"
+            echo "* **Accuracy dataset:** $ACCURACY_PATH"
+            echo ""
+            echo "#### Weekly statistics"
+            echo '```'
+            cat "$SUMMARY_FILE"
+            echo '```'
+            echo ""
+            echo "#### Latest log entry"
+            if [[ -s $LOG_PATH ]]; then
+              echo '```'
+              tail -n 1 "$LOG_PATH"
+              echo '```'
+            else
+              echo "No log entries recorded."
+            fi
+            echo ""
+            echo "#### Accuracy dataset preview"
+            if [[ -s $ACCURACY_PATH ]]; then
+              echo '```'
+              head -n 10 "$ACCURACY_PATH"
+              echo '```'
+            else
+              echo "Accuracy dataset is empty."
+            fi
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Upload pipeline artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: weather-pipeline-${{ github.run_id }}
+          path: pipeline_outputs/
+          retention-days: 7

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,15 @@ By following the exercises in this project you will learn how to:
 4. Generate the accuracy dataset with `./fc_accuracy.sh`. When the log contains at least two entries, the script will produce `historical_fc_accuracy.tsv` with signed errors and qualitative accuracy ranges.
 5. Summarize the latest forecast performance with `./weekly_stats.sh [path/to/accuracy.tsv]`, which reports the minimum and maximum absolute error across the most recent seven records.
 
+## GitHub Actions automation
+
+Trigger the **Weather data pipeline** workflow from the **Actions** tab to run the full ETL on a GitHub-hosted runner. The workflow accepts an optional `city` input (default: Casablanca) and performs the following steps:
+
+1. Initializes isolated copies of the log, accuracy dataset, and manual input template.
+2. Calls `rx_poc.sh` to fetch the latest observation and next-day forecast for the requested city.
+3. Builds the historical accuracy file with `fc_accuracy.sh` and, when enough records exist, generates weekly statistics.
+4. Publishes a run summary and uploads the generated artifacts so you can review the log, accuracy dataset, and raw payload directly from GitHub.
+
 
 ## Prerequisites
 - Linux or macOS environment with Bash 4+, `curl`, `wget`, `grep`, `cut`, `head`, `tail`, and `date` available.


### PR DESCRIPTION
## Summary
- add a workflow_dispatch GitHub Actions workflow that runs the Bash ETL scripts and posts a run summary
- upload generated weather log, accuracy dataset, and raw payload as run artifacts for review
- document how to trigger the workflow and what it does in the README

## Testing
- not run (workflow definition only)


------
https://chatgpt.com/codex/tasks/task_e_68ca912bab2c832784e831a1df61ffbc